### PR TITLE
XSS attack spoil bug fixed

### DIFF
--- a/dateable/chronos/browser/base_view.py
+++ b/dateable/chronos/browser/base_view.py
@@ -1,3 +1,4 @@
+import sys
 import BTrees
 import datetime
 import calendar
@@ -11,12 +12,12 @@ from zope.contentprovider.interfaces import IContentProvider
 from zope.app.publisher.interfaces.browser import IBrowserMenu
 
 from Products.CMFCore.utils import getToolByName
-try:
-# Plone 4
-    from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation as IDynamicallyViewable
-except:
-# Plone 3
+if sys.version_info < (2, 6):
+    # Plone 3
     from Products.CMFDynamicViewFTI.interfaces import IDynamicallyViewable
+else:
+    # Plone 4
+    from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation as IDynamicallyViewable
 
 from dateable.chronos import utils
 from dateable.chronos.browser.interfaces import ICalendarView

--- a/dateable/chronos/browser/displays.py
+++ b/dateable/chronos/browser/displays.py
@@ -1,13 +1,14 @@
+import sys
 from zope.interface import implements
 from zope.component import adapts
 from dateable.chronos.interfaces import ICalendarEnhanced
 
-try:
-# Plone 4
-    from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation as IDynamicallyViewable
-except:
-# Plone 3
+if sys.version_info < (2, 6):
+    # Plone 3
     from Products.CMFDynamicViewFTI.interfaces import IDynamicallyViewable
+else:
+    # Plone 4
+    from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation as IDynamicallyViewable
 
 
 # XXX This seems to not be used. But it should be, I think.

--- a/dateable/chronos/utils.py
+++ b/dateable/chronos/utils.py
@@ -1,4 +1,5 @@
 import calendar
+import re
 from datetime import date
 
 
@@ -15,7 +16,7 @@ def get_view_day(request):
     if 'date' in request.form:
         # A new date was passed in. Switch date:
         date_str = request.form['date']
-        if not date_str:
+        if not date_str or not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
             # The string as empty: Return today.
             return date.today()
         year, month, day = date_str.split('-')

--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -12,6 +12,8 @@ dateable.chronos Changes
   can be customized through portal_view_customizations
   [swampmonkey]
 
+- Fixed a XSS vulnerability in the get_view_day method
+  [keul]
 
 dateable.chronos 0.7.1 (2010-08-01)
 ===================================


### PR DESCRIPTION
Hi, a customer security check of sites with p4a.calendar found that calling the month.html, week.html with evil parameters can expose the site to some kind of attack.

Two example:
- http://youthost/calendar/week.html?date= 2011-09-01'%0D%0AContent−Type: text/html%0D%0A<html><ScRiPt %0A%0D>alert(123)%3B</ScRiPt></html>
  This raise an alert in the client window
- http://youthost/calendar/week.html?date= 2011-09-01'%0D%0AContent−Type: text/html%0D%0A<html>;</html>
  This raise Zope ugly Zope errors.

As our customer use Plone 3.2, we restored also the Plone 3 compatibility. Seems that the use of try/except ImportError was not working (the import was succesfull also on Plone 3, but with bad results).
